### PR TITLE
Remove broken RSS fallback for Revue FAR (feed URL returns 404)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1432,45 +1432,9 @@ async function loadInitialFarRevues() {
         if (revues.length > 0 && farLoadedPages < FAR_PAGES.length) {
             document.getElementById('farShowMore').style.display = 'flex';
         }
-
-        // If HTML scraping returned nothing, fallback to RSS
-        if (revues.length === 0) {
-            console.warn('FAR HTML scraping returned 0 results, falling back to RSS');
-            await loadFarFromRSS();
-        }
     } catch (e) {
-        console.warn('FAR HTML scraping failed, falling back to RSS:', e);
-        await loadFarFromRSS();
-    }
-}
-
-// Fallback: load Revue FAR from RSS feed if HTML scraping fails
-async function loadFarFromRSS() {
-    try {
-        const farFeed = { id: 'far-revue', cat: 'far', name: 'Revue FAR', url: 'https://revue.far.ma/feed/', color: '#5b6e1e' };
-        const xml = await fetchWithFallback(farFeed.url);
-        const articles = parseRSS(xml, farFeed);
-
-        // Try to derive cover image URLs from article links
-        // Pattern: edition link like /editon431... → image /storage/revues/CouvE431.png
-        farRevues = articles.map(a => {
-            let image = a.image || '';
-            if (!image) {
-                const edMatch = a.link.match(/editon(\d+)/);
-                if (edMatch) {
-                    image = `${FAR_BASE}/storage/revues/CouvE${edMatch[1]}.png`;
-                }
-            }
-            return { title: a.title, link: a.link, image, source: 'Revue FAR', cat: 'far' };
-        });
-
-        farLoadedPages = FAR_PAGES[FAR_PAGES.length - 1]; // No more pages to load
-        feedResults['far-revue'] = { ok: farRevues.length > 0, count: farRevues.length };
-        renderFarSection();
-        renderFeedStatus();
-    } catch (e2) {
-        console.warn('FAR RSS fallback also failed:', e2);
-        feedResults['far-revue'] = { ok: false, count: 0, error: 'Failed to load' };
+        console.warn('FAR scraping failed:', e);
+        feedResults['far-revue'] = { ok: false, count: 0, error: e.message || 'Failed to load' };
         renderFeedStatus();
     }
 }


### PR DESCRIPTION
The revue.far.ma/feed/ endpoint no longer exists. Revue FAR data is only available via HTML scraping from revue.far.ma/revues?page=N. Simplified loadInitialFarRevues to just report failure gracefully when the site is unavailable (currently returning 503).

https://claude.ai/code/session_01JhdcvxD8LDo1BrT2b8QxLf